### PR TITLE
Bump to latest parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,14 +3,19 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.37</version>
+    <version>3.9</version>
   </parent>
 
-  <groupId>org.jenkins-ci.plugins</groupId>
   <artifactId>extension-filter</artifactId>
   <version>1.1-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <url>https://wiki.jenkins-ci.org/display/JENKINS/Extension+Filter+Plugin</url>
+
+  <properties>
+    <jenkins.version>2.60.3</jenkins.version>
+    <java.level>8</java.level>
+  </properties>
+
   <licenses>
     <license>
       <name>MIT</name>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.472</version>
+    <version>2.37</version>
   </parent>
 
   <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/org/jenkinsci/plugins/ConfigurableExtensionFilter.java
+++ b/src/main/java/org/jenkinsci/plugins/ConfigurableExtensionFilter.java
@@ -8,6 +8,9 @@ import jenkins.ExtensionFilter;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.StaplerRequest;
 
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+
 public class ConfigurableExtensionFilter extends AbstractDescribableImpl<ConfigurableExtensionFilter> {
 
     @Extension
@@ -28,8 +31,9 @@ public class ConfigurableExtensionFilter extends AbstractDescribableImpl<Configu
     public final static DescriptorVisibilityFilter DESCRIPTOR_FILTER = new DescriptorVisibilityFilter() {
 
         @Override
-        public boolean filter(Object context, Descriptor descriptor) {
-            return DESCRIPTOR.allows(context.getClass(), descriptor.getClass().getName());
+        public boolean filter(@CheckForNull Object context, @Nonnull Descriptor descriptor) {
+            Class contextClass = context == null ? null : context.getClass();
+            return DESCRIPTOR.allows(contextClass, descriptor.getClass().getName());
         }
     };
 

--- a/src/main/java/org/jenkinsci/plugins/ConfigurableExtensionFilter.java
+++ b/src/main/java/org/jenkinsci/plugins/ConfigurableExtensionFilter.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.plugins;
-import hudson.ExtensionComponent;
+
 import hudson.Extension;
+import hudson.ExtensionComponent;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
 import hudson.model.DescriptorVisibilityFilter;
@@ -10,6 +11,7 @@ import org.kohsuke.stapler.StaplerRequest;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+import java.util.Arrays;
 
 public class ConfigurableExtensionFilter extends AbstractDescribableImpl<ConfigurableExtensionFilter> {
 
@@ -46,13 +48,16 @@ public class ConfigurableExtensionFilter extends AbstractDescribableImpl<Configu
             load();
         }
 
-        private Exclusion[] exclusions;
+        private Exclusion[] exclusions = new Exclusion[0];
 
         public Exclusion[] getExclusions() {
             return exclusions.clone();
         }
 
-        public void setExclusions(Exclusion[] exclusions) {
+        public void setExclusions(@Nonnull Exclusion[] exclusions) {
+            if (exclusions == null) {
+                throw new IllegalArgumentException("Passed 'exclusions' array must be non null");
+            }
             this.exclusions = exclusions.clone();
         }
 

--- a/src/main/java/org/jenkinsci/plugins/ConfigurableExtensionFilter.java
+++ b/src/main/java/org/jenkinsci/plugins/ConfigurableExtensionFilter.java
@@ -45,11 +45,11 @@ public class ConfigurableExtensionFilter extends AbstractDescribableImpl<Configu
         private Exclusion[] exclusions;
 
         public Exclusion[] getExclusions() {
-            return exclusions;
+            return exclusions.clone();
         }
 
         public void setExclusions(Exclusion[] exclusions) {
-            this.exclusions = exclusions;
+            this.exclusions = exclusions.clone();
         }
 
         @Override

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <!--
   This view is used to render the installed plugins page.
 -->

--- a/src/main/resources/org/jenkinsci/plugins/ConfigurableExtensionFilter/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ConfigurableExtensionFilter/global.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:section title="Extension Filter">
     <f:entry title="Exclusions"

--- a/src/test/java/org/jenkinsci/plugins/ConfigurableExtensionFilterTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ConfigurableExtensionFilterTest.java
@@ -1,0 +1,26 @@
+package org.jenkinsci.plugins;
+
+import org.jenkinsci.plugins.ConfigurableExtensionFilter.DescriptorImpl;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.junit.Assert.assertNotNull;
+
+public class ConfigurableExtensionFilterTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void nullSafety() {
+        DescriptorImpl impl = new DescriptorImpl();
+        assertNotNull(impl.getExclusions());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void cannotSetNull() {
+        DescriptorImpl impl = new DescriptorImpl();
+        impl.setExclusions(null);
+    }
+}


### PR DESCRIPTION
In case, as I suspect, we need to hide some things like FreeStyle jobs from _Jenkins Essentials_, having this plugin up to date and _Incrementals_-ready could be good. 

(note: for _Incrementals_-readiness, we'd need to [do some other things](https://github.com/jenkinsci/pom/blob/master/incrementals.md), but being already on the [3.9](https://github.com/jenkinsci/plugin-pom/blob/master/CHANGELOG.md#39) would be a good start).