### PR TITLE
Resolve default value breaking empty context form round trip

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/ConfigurableExtensionFilter/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ConfigurableExtensionFilter/global.jelly
@@ -9,7 +9,7 @@
             <f:textbox name="fqcn"/>
           </f:entry>
           <f:entry title="${%Context}" field="context">
-            <f:textbox default="jenkins.model.Jenkins"/>
+            <f:textbox default="${null}"/>
           </f:entry>
           <f:entry title="">
             <div align="right">

--- a/src/test/java/org/jenkinsci/plugins/ConfigurableExtensionFilterTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ConfigurableExtensionFilterTest.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import org.jenkinsci.plugins.ConfigurableExtensionFilter.DescriptorImpl;
@@ -22,5 +23,15 @@ public class ConfigurableExtensionFilterTest {
     public void cannotSetNull() {
         DescriptorImpl impl = new DescriptorImpl();
         impl.setExclusions(null);
+    }
+
+    @Test
+    public void testConfigRoundtrip() throws Exception {
+        DescriptorImpl impl = new DescriptorImpl();
+        impl.setExclusions(new Exclusion[0]);
+
+        j.configRoundtrip();
+
+        assertEquals(0, impl.getExclusions().length);
     }
 }


### PR DESCRIPTION
Closes #49 

I am not sure about removing the default value in the context field. I thought one can easily understand about context with the help of `help-context.html`

cc: @jonesbusy 