### PR TITLE
Modernize Extension and avoid Guice circular dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,11 @@
       <artifactId>test-harness</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <repositories>

--- a/src/test/java/org/jenkinsci/plugins/ConfigurableExtensionFilterTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ConfigurableExtensionFilterTest.java
@@ -3,6 +3,7 @@ package org.jenkinsci.plugins;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
+import jenkins.ExtensionFilter;
 import org.jenkinsci.plugins.ConfigurableExtensionFilter.DescriptorImpl;
 import org.junit.Rule;
 import org.junit.Test;
@@ -33,5 +34,12 @@ public class ConfigurableExtensionFilterTest {
         j.configRoundtrip();
 
         assertEquals(0, impl.getExclusions().length);
+    }
+
+    @Test
+    public void testGetExtensionFilter() {
+        ExtensionFilter extensionFilter = ConfigurableExtensionFilter.getExtensionFilter();
+
+        assertNotNull(extensionFilter);
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/ExclusionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ExclusionTest.java
@@ -1,0 +1,63 @@
+package org.jenkinsci.plugins;
+
+import static org.junit.Assert.assertEquals;
+
+import hudson.util.FormValidation;
+import org.junit.Test;
+
+public class ExclusionTest {
+
+    private Exclusion.DescriptorImpl descriptor = new Exclusion.DescriptorImpl();
+
+    @Test
+    public void testGetFqcn() {
+        String fqcn = "hudson.testfqcn";
+        String context = "testContext";
+        Exclusion exclusion = new Exclusion(fqcn, context);
+
+        String result = exclusion.getFqcn();
+
+        assertEquals(fqcn, result);
+    }
+
+    @Test
+    public void testGetContext() {
+        String fqcn = "hudson.testfqcn";
+        String context = "testContext";
+        Exclusion exclusion = new Exclusion(fqcn, context);
+
+        String result = exclusion.getContext();
+
+        assertEquals(context, result);
+    }
+
+    @Test
+    public void testValidDescriptorWithSample() {
+        FormValidation validation = descriptor.doCheckFqcn("hudson.tasks.Maven$DescriptorImpl");
+        assertEquals(FormValidation.Kind.OK, validation.kind);
+    }
+
+    @Test
+    public void testValidExtensionWithSample() {
+        FormValidation validation = descriptor.doCheckFqcn("hudson.model.AdministrativeMonitor");
+        assertEquals(FormValidation.Kind.OK, validation.kind);
+    }
+
+    @Test
+    public void testValidExtensionAndDescriptorWithSample() {
+        FormValidation validation = descriptor.doCheckFqcn("jenkins.tasks.filters.EnvVarsFilterLocalRule");
+        assertEquals(FormValidation.Kind.OK, validation.kind);
+    }
+
+    @Test
+    public void testInvalidClassWithSample() {
+        FormValidation validation = descriptor.doCheckFqcn("hudson.Util");
+        assertEquals(FormValidation.Kind.ERROR, validation.kind);
+    }
+
+    @Test
+    public void testClassNotFound() {
+        FormValidation validation = descriptor.doCheckFqcn("");
+        assertEquals(FormValidation.Kind.ERROR, validation.kind);
+    }
+}


### PR DESCRIPTION
Closes #54 

- Used lazy initialization to resolve the circular dependency issue
- Written few simple test cases to increase code coverage

### Testing:

https://github.com/jenkinsci/extension-filter-plugin/assets/107404972/237cde9a-49ce-4634-91db-dabfca8fe41b


https://github.com/jenkinsci/extension-filter-plugin/assets/107404972/973d148d-a3a3-41f1-a513-4b6e3df3060c

cc: @jonesbusy 
