### PR TITLE
Fix Error. Class not found for class not visible by plugin class loader

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/Exclusion.java
+++ b/src/main/java/org/jenkinsci/plugins/Exclusion.java
@@ -8,6 +8,7 @@ import hudson.model.Descriptor;
 import hudson.util.FormValidation;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import jenkins.model.Jenkins;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 
@@ -46,9 +47,7 @@ public class Exclusion extends AbstractDescribableImpl<Exclusion> {
         public FormValidation doCheckFqcn(@QueryParameter String fqcn) {
             Class definedClass;
             try {
-                // TODO: Doesn't work with extension points defined in plugins. Is there a better way to ask Jenkins
-                // Core for class existence?
-                definedClass = Class.forName(fqcn);
+                definedClass = Jenkins.get().pluginManager.uberClassLoader.loadClass(fqcn);
             } catch (ClassNotFoundException e) {
                 LOGGER.log(Level.WARNING, "Failed to load class " + fqcn);
                 return FormValidation.error(Messages.Exclusion_classNotFoundMsg());

--- a/src/test/java/org/jenkinsci/plugins/ExclusionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ExclusionTest.java
@@ -3,14 +3,15 @@ package org.jenkinsci.plugins;
 import static org.junit.Assert.assertEquals;
 
 import hudson.util.FormValidation;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
+@WithJenkins
 public class ExclusionTest {
 
-    private Exclusion.DescriptorImpl descriptor = new Exclusion.DescriptorImpl();
-
     @Test
-    public void testGetFqcn() {
+    public void testGetFqcn(JenkinsRule jenkinsRule) {
         String fqcn = "hudson.testfqcn";
         String context = "testContext";
         Exclusion exclusion = new Exclusion(fqcn, context);
@@ -21,7 +22,7 @@ public class ExclusionTest {
     }
 
     @Test
-    public void testGetContext() {
+    public void testGetContext(JenkinsRule jenkinsRule) {
         String fqcn = "hudson.testfqcn";
         String context = "testContext";
         Exclusion exclusion = new Exclusion(fqcn, context);
@@ -32,31 +33,36 @@ public class ExclusionTest {
     }
 
     @Test
-    public void testValidDescriptorWithSample() {
+    public void testValidDescriptorWithSample(JenkinsRule jenkinsRule) {
+        Exclusion.DescriptorImpl descriptor = jenkinsRule.jenkins.getDescriptorByType(Exclusion.DescriptorImpl.class);
         FormValidation validation = descriptor.doCheckFqcn("hudson.tasks.Maven$DescriptorImpl");
         assertEquals(FormValidation.Kind.OK, validation.kind);
     }
 
     @Test
-    public void testValidExtensionWithSample() {
+    public void testValidExtensionWithSample(JenkinsRule jenkinsRule) {
+        Exclusion.DescriptorImpl descriptor = jenkinsRule.jenkins.getDescriptorByType(Exclusion.DescriptorImpl.class);
         FormValidation validation = descriptor.doCheckFqcn("hudson.model.AdministrativeMonitor");
         assertEquals(FormValidation.Kind.OK, validation.kind);
     }
 
     @Test
-    public void testValidExtensionAndDescriptorWithSample() {
+    public void testValidExtensionAndDescriptorWithSample(JenkinsRule jenkinsRule) {
+        Exclusion.DescriptorImpl descriptor = jenkinsRule.jenkins.getDescriptorByType(Exclusion.DescriptorImpl.class);
         FormValidation validation = descriptor.doCheckFqcn("jenkins.tasks.filters.EnvVarsFilterLocalRule");
         assertEquals(FormValidation.Kind.OK, validation.kind);
     }
 
     @Test
-    public void testInvalidClassWithSample() {
+    public void testInvalidClassWithSample(JenkinsRule jenkinsRule) {
+        Exclusion.DescriptorImpl descriptor = jenkinsRule.jenkins.getDescriptorByType(Exclusion.DescriptorImpl.class);
         FormValidation validation = descriptor.doCheckFqcn("hudson.Util");
         assertEquals(FormValidation.Kind.ERROR, validation.kind);
     }
 
     @Test
-    public void testClassNotFound() {
+    public void testClassNotFound(JenkinsRule jenkinsRule) {
+        Exclusion.DescriptorImpl descriptor = jenkinsRule.jenkins.getDescriptorByType(Exclusion.DescriptorImpl.class);
         FormValidation validation = descriptor.doCheckFqcn("");
         assertEquals(FormValidation.Kind.ERROR, validation.kind);
     }


### PR DESCRIPTION
Use uberClassloader from plugin manager and all loaded plugins

### Testing done

Manual tests and run automated tests

![Screenshot from 2024-03-02 19-09-59](https://github.com/jenkinsci/extension-filter-plugin/assets/825750/cad824e1-7ed1-437a-8207-53a2ed5b4b29)

![Screenshot from 2024-03-02 19-10-16](https://github.com/jenkinsci/extension-filter-plugin/assets/825750/534c93f8-7b42-48a4-9836-62f53b696075)

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
