### PR TITLE
Migrate tests to JUnit5

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/ConfigurableExtensionFilterTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ConfigurableExtensionFilterTest.java
@@ -1,9 +1,8 @@
 package org.jenkinsci.plugins;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import hudson.ExtensionList;
 import org.junit.jupiter.api.Test;
@@ -11,30 +10,24 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
 @WithJenkins
-public class ConfigurableExtensionFilterTest {
+class ConfigurableExtensionFilterTest {
 
     @Test
-    public void nullSafety(JenkinsRule j) {
+    void nullSafety(JenkinsRule j) {
         ConfigurableExtensionFilter.DescriptorImpl impl =
                 ExtensionList.lookupSingleton(ConfigurableExtensionFilter.DescriptorImpl.class);
         assertNotNull(impl.getExclusions());
     }
 
     @Test
-    public void cannotSetNull(JenkinsRule j) {
-        try {
-            ConfigurableExtensionFilter.DescriptorImpl impl =
-                    ExtensionList.lookupSingleton(ConfigurableExtensionFilter.DescriptorImpl.class);
-            impl.setExclusions(null);
-            fail("Expected IllegalArgumentException");
-        } catch (IllegalArgumentException e) {
-            return;
-        }
-        fail("Expected IllegalArgumentException");
+    void cannotSetNull(JenkinsRule j) {
+        ConfigurableExtensionFilter.DescriptorImpl impl =
+                ExtensionList.lookupSingleton(ConfigurableExtensionFilter.DescriptorImpl.class);
+        assertThrows(IllegalArgumentException.class, () -> impl.setExclusions(null));
     }
 
     @Test
-    public void testConfigRoundtrip(JenkinsRule j) throws Exception {
+    void testConfigRoundtrip(JenkinsRule j) throws Exception {
         ConfigurableExtensionFilter.DescriptorImpl impl =
                 ExtensionList.lookupSingleton(ConfigurableExtensionFilter.DescriptorImpl.class);
         impl.setExclusions(new Exclusion[0]);
@@ -43,8 +36,7 @@ public class ConfigurableExtensionFilterTest {
     }
 
     @Test
-    public void testExtensionNotVisible(JenkinsRule j) throws Exception {
-
+    void testExtensionNotVisible(JenkinsRule j) {
         // Get our descriptor
         ConfigurableExtensionFilter.DescriptorImpl impl =
                 ExtensionList.lookupSingleton(ConfigurableExtensionFilter.DescriptorImpl.class);

--- a/src/test/java/org/jenkinsci/plugins/ConfigurationAsCodeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ConfigurationAsCodeTest.java
@@ -1,22 +1,20 @@
 package org.jenkinsci.plugins;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
 import jenkins.model.Jenkins;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ConfigurationAsCodeTest {
-
-    @Rule
-    public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
+@WithJenkinsConfiguredWithCode
+class ConfigurationAsCodeTest {
 
     @Test
     @ConfiguredWithCode("configuration-as-code.yml")
-    public void shouldSupportConfigurationAsCode() throws Exception {
+    void shouldSupportConfigurationAsCode(JenkinsConfiguredWithCodeRule j) {
         ConfigurableExtensionFilter.DescriptorImpl extension = Jenkins.get()
                 .getExtensionList(ConfigurableExtensionFilter.DescriptorImpl.class)
                 .get(0);

--- a/src/test/java/org/jenkinsci/plugins/ExclusionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ExclusionTest.java
@@ -1,6 +1,6 @@
 package org.jenkinsci.plugins;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import hudson.util.FormValidation;
 import org.junit.jupiter.api.Test;
@@ -8,10 +8,10 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
 @WithJenkins
-public class ExclusionTest {
+class ExclusionTest {
 
     @Test
-    public void testGetFqcn(JenkinsRule jenkinsRule) {
+    void testGetFqcn(JenkinsRule jenkinsRule) {
         String fqcn = "hudson.testfqcn";
         String context = "testContext";
         Exclusion exclusion = new Exclusion(fqcn, context);
@@ -22,7 +22,7 @@ public class ExclusionTest {
     }
 
     @Test
-    public void testGetContext(JenkinsRule jenkinsRule) {
+    void testGetContext(JenkinsRule jenkinsRule) {
         String fqcn = "hudson.testfqcn";
         String context = "testContext";
         Exclusion exclusion = new Exclusion(fqcn, context);
@@ -33,35 +33,35 @@ public class ExclusionTest {
     }
 
     @Test
-    public void testValidDescriptorWithSample(JenkinsRule jenkinsRule) {
+    void testValidDescriptorWithSample(JenkinsRule jenkinsRule) {
         Exclusion.DescriptorImpl descriptor = jenkinsRule.jenkins.getDescriptorByType(Exclusion.DescriptorImpl.class);
         FormValidation validation = descriptor.doCheckFqcn("hudson.tasks.Maven$DescriptorImpl");
         assertEquals(FormValidation.Kind.OK, validation.kind);
     }
 
     @Test
-    public void testValidExtensionWithSample(JenkinsRule jenkinsRule) {
+    void testValidExtensionWithSample(JenkinsRule jenkinsRule) {
         Exclusion.DescriptorImpl descriptor = jenkinsRule.jenkins.getDescriptorByType(Exclusion.DescriptorImpl.class);
         FormValidation validation = descriptor.doCheckFqcn("hudson.model.AdministrativeMonitor");
         assertEquals(FormValidation.Kind.OK, validation.kind);
     }
 
     @Test
-    public void testValidExtensionAndDescriptorWithSample(JenkinsRule jenkinsRule) {
+    void testValidExtensionAndDescriptorWithSample(JenkinsRule jenkinsRule) {
         Exclusion.DescriptorImpl descriptor = jenkinsRule.jenkins.getDescriptorByType(Exclusion.DescriptorImpl.class);
         FormValidation validation = descriptor.doCheckFqcn("jenkins.tasks.filters.EnvVarsFilterLocalRule");
         assertEquals(FormValidation.Kind.OK, validation.kind);
     }
 
     @Test
-    public void testInvalidClassWithSample(JenkinsRule jenkinsRule) {
+    void testInvalidClassWithSample(JenkinsRule jenkinsRule) {
         Exclusion.DescriptorImpl descriptor = jenkinsRule.jenkins.getDescriptorByType(Exclusion.DescriptorImpl.class);
         FormValidation validation = descriptor.doCheckFqcn("hudson.Util");
         assertEquals(FormValidation.Kind.ERROR, validation.kind);
     }
 
     @Test
-    public void testClassNotFound(JenkinsRule jenkinsRule) {
+    void testClassNotFound(JenkinsRule jenkinsRule) {
         Exclusion.DescriptorImpl descriptor = jenkinsRule.jenkins.getDescriptorByType(Exclusion.DescriptorImpl.class);
         FormValidation validation = descriptor.doCheckFqcn("");
         assertEquals(FormValidation.Kind.ERROR, validation.kind);


### PR DESCRIPTION
This PR aims to migrate all tests to JUnit5. Changes include:

* Migrate annotations and imports
* Migrate assertions
* Remove public visibility for test classes and methods
* Minor clean up

I am well aware that this is a quite large changeset however I hope that there is still interest in this PR and it will be reviewed.
If there are any questions, please do not hesitate to ping me.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub 
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
